### PR TITLE
Music disc loot

### DIFF
--- a/src/main/resources/data/minecraft/tags/items/creeper_drop_music_discs.json
+++ b/src/main/resources/data/minecraft/tags/items/creeper_drop_music_discs.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "unordinary_basics:music_disc_queen"
+  ]
+}


### PR DESCRIPTION
#130 music_disc_queen can now drop when a skeleton kills a creeper.